### PR TITLE
Update webviewContent.ts

### DIFF
--- a/src/webviewContent.ts
+++ b/src/webviewContent.ts
@@ -265,7 +265,7 @@ export function getWebviewContent(cspSource: string, assetsPath: Uri) {
 		<p>Stash modified and staged changes with a custom message</p>
 		<div class="command-wrapper">
 			<button type="button" class="btn btn-copy">Copy</button>
-			<pre>git stash save -m "message"</pre>
+			<pre>git stash push -m "message"</pre>
 		</div>
 
 		<p>List all stashed changesets</p>


### PR DESCRIPTION
@dzhavat `git stash save` has been marked deprecated. Check the [official docs](https://git-scm.com/docs/git-stash#_description). Maybe it would be good to keep the cheatsheet updated as well 🙂 . Cheers!